### PR TITLE
Fix metrics.run to work with pandas >= 1.1.0

### DIFF
--- a/crowdtruth/models/metrics.py
+++ b/crowdtruth/models/metrics.py
@@ -393,8 +393,11 @@ class Metrics():
             return vector
 
         # fill judgment vectors with unit keys
+        collector = []
         for index, row in judgments.iterrows():
-            judgments.at[index, col] = expanded_vector(row[col], units.at[row['unit'], col])
+            collector.append(expanded_vector(row[col], units.at[row['unit'], col]))
+        judgments[col] = collector
+
 
         unit_work_ann_dict = judgments[['unit', 'worker', col]].copy().groupby('unit')
         unit_work_ann_dict = {name : group.set_index('worker')[col].to_dict() \


### PR DESCRIPTION
@ancadumitrache This PR is a small fix to solve some issues we ran into while using `pandas >= 1.1.0` it's been tested with `pandas == 1.2.4` and we got the same results as before.

Please consider this PR for a main stream merge and release !

Thanks